### PR TITLE
Added verify=false in Guzzle/Client

### DIFF
--- a/src/Service/ApiClient.php
+++ b/src/Service/ApiClient.php
@@ -15,6 +15,7 @@ class ApiClient
     {
         $this->client = $client = new Client(array(
             'base_uri' => $url,
+            'verify' => false
         ));
     }
 


### PR DESCRIPTION
Added verify=false in Guzzle/Client construct in order to ignore invalid SSL certificate errors